### PR TITLE
fix browser, browser context and page links

### DIFF
--- a/tutorial/2-first-steps.md
+++ b/tutorial/2-first-steps.md
@@ -10,17 +10,17 @@ It will also cover basic Playwright API calls.
 Before we can automate interactions using Playwright's API, we must first understand how Playwright interacts with browsers.
 There are three main layers to automation: *browsers*, *browser contexts*, and *pages*:
 
-1. A [browser](https://playwright.dev/python/docs/browsers/)
+1. A [browser](https://playwright.dev/python/docs/browsers)
    is a single instance of a web browser.
    Playwright will automatically launch a browser instance specified by code or by inputs.
    Typically, this is either the Chromium, Firefox, or WebKit instance installed via `playwright install`,
    but it may also be other browsers installed on your local machine.
-2. A [browser context](https://playwright.dev/python/docs/browser-contexts/)
+2. A [browser context](https://playwright.dev/python/docs/browser-contexts)
    is an isolated incognito-alike session within a browser instance.
    They are fast and cheap to create.
    One browser may have multiple browser contexts.
    The recommended practice is for all tests to share one browser instance but for each test to have its own browser context.
-3. A [page](https://playwright.dev/python/docs/pages/)
+3. A [page](https://playwright.dev/python/docs/pages)
    is a single tab or window within a browser context.
    A browser context may have multiple pages.
    Typically, an individual test should interact with only one page.


### PR DESCRIPTION
remove forward slash from the of browser, browser context and page links to avoid open "page not found" page